### PR TITLE
Update version to 1.1.6 and log DeepL error status code

### DIFF
--- a/packages/localize_it/.dart_tool/package_config.json
+++ b/packages/localize_it/.dart_tool/package_config.json
@@ -440,7 +440,7 @@
       "languageVersion": "3.2"
     }
   ],
-  "generated": "2025-04-21T16:39:52.138818Z",
+  "generated": "2025-08-07T12:30:05.452214Z",
   "generator": "pub",
   "generatorVersion": "3.7.2",
   "flutterRoot": "file:///Users/christiankonnerth/fvm/versions/3.29.2",

--- a/packages/localize_it/CHANGELOG.md
+++ b/packages/localize_it/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.6
+- Log error status code when DeepL fails
+
 ## 1.1.5
 - Request delay to avoid DeepL timeout
 - Option to log translations 

--- a/packages/localize_it/lib/src/localizer.dart
+++ b/packages/localize_it/lib/src/localizer.dart
@@ -491,7 +491,10 @@ class Localizer extends GeneratorForAnnotation<LocalizeItAnnotation> {
 
       if (response.statusCode != 200) {
         stdout.writeln(
-          '❗️   Something went wrong while translating with DeepL: ${response.body}',
+          '❗️   Something went wrong while translating with DeepL...',
+        );
+        stdout.writeln(
+          '❗️   Status Code: ${response.statusCode}',
         );
         missingLocalizationsCounter++;
         return missingTranslationPlaceholderText;

--- a/packages/localize_it/pubspec.yaml
+++ b/packages/localize_it/pubspec.yaml
@@ -3,7 +3,7 @@ description: A tool for making localizing your Flutter App easy peasy lemmon squ
 homepage: https://github.com/DieGlueckswurst/localize_it
 repository: https://github.com/DieGlueckswurst/localize_it
 issue_tracker: https://github.com/DieGlueckswurst/localize_it/issues
-version: 1.1.5
+version: 1.1.6
 platforms:
   android:
   ios:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for DeepL translation failures by displaying the error status code separately for easier troubleshooting.

* **Documentation**
  * Updated the changelog to reflect the new error logging behavior.

* **Chores**
  * Bumped the package version to 1.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->